### PR TITLE
Remove duplicates in documenting trait members

### DIFF
--- a/autodoc_traits/autodoc_traits.py
+++ b/autodoc_traits/autodoc_traits.py
@@ -25,7 +25,13 @@ class ConfigurableDocumenter(ClassDocumenter):
             # put help in __doc__ where autodoc will look for it
             trait.__doc__ = trait.help
             trait_members.append((name, trait))
-        return check, trait_members + members
+        # Remove duplicates between members and trait_members.  We
+        # can't use sets, because not all items are hashable.  Modify
+        # trait_members in place for returning.
+        for item in members:
+            if item not in trait_members:
+                trait_members.append(item)
+        return check, trait_members
 
 
 class TraitDocumenter(AttributeDocumenter):


### PR DESCRIPTION
- When run with the `:members:`, then traitlets traits are duplicated,
  because they are added to the autodoc list from both from
  `:members:` and this autodetection. (I think)
- Discussed in at least
  https://github.com/jupyterhub/jupyterhub/pull/2726.  Currently
  causing JupyterHub docs to fail, because sphinx gives an error if
  there are duplicate autodoced traits and it is run with `-W`.
- This seems to be started in a new version of sphinx, but we aren't
  completly sure.  JH has been using the `-W` option since 2017.
- I'm unsure if this is the right solution, but it works and gets me
  past these errors.