### PR TITLE
Remove unused import of deprecated PyClassmember

### DIFF
--- a/autodoc_traits/autodoc_traits.py
+++ b/autodoc_traits/autodoc_traits.py
@@ -1,5 +1,4 @@
 """autodoc extension for configurable traits"""
-from sphinx.domains.python import PyClassmember
 from sphinx.ext.autodoc import AttributeDocumenter
 from sphinx.ext.autodoc import ClassDocumenter
 from traitlets import TraitType


### PR DESCRIPTION
it's gone in sphinx 4, preventing jupyterhub docs builds from succeeding

closes #2 