### PR TITLE
add publish github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+# Build releases and (on tags) publish to PyPI
+name: Release
+
+# always build releases (to make sure wheel-building works)
+# but only publish to PyPI on tags
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: install build package
+        run: |
+          pip install --upgrade pip
+          pip install build
+          pip freeze
+
+      - name: build release
+        run: |
+          python -m build --sdist --wheel .
+          ls -l dist
+
+      - name: publish to pypi
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/autodoc_traits/__init__.py
+++ b/autodoc_traits/__init__.py
@@ -1,5 +1,7 @@
-__version__ = '0.1.0dev'
+__version__ = "0.1.0dev"
+
 
 def setup(app, *args, **kwargs):
     from .autodoc_traits import setup
+
     return setup(app, *args, **kwargs)


### PR DESCRIPTION
so releases can be published by pushing tags. Version still needs to be bumped in `__init__`.


Still needs a token added in PYPI_PASSWORD secret. Only @willingc has permission at the moment, I think.
