### PR TITLE
Point url to the GitHub repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     description="Sphinx extension to autodoc traitlets",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://jupyter.org",
+    url="https://github.com/jupyterhub/autodoc-traits",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Currently it points to jupyter.org, which isn't as useful when clicking
'Homepage' in https://pypi.org/project/autodoc-traits/