### PR TITLE
Fix failure to use autoclass on non-traitlets configurable classes

### DIFF
--- a/autodoc_traits/autodoc_traits.py
+++ b/autodoc_traits/autodoc_traits.py
@@ -1,6 +1,7 @@
 """autodoc extension for configurable traits"""
 from sphinx.ext.autodoc import AttributeDocumenter
 from sphinx.ext.autodoc import ClassDocumenter
+from traitlets import MetaHasTraits
 from traitlets import TraitType
 from traitlets import Undefined
 
@@ -14,6 +15,8 @@ class ConfigurableDocumenter(ClassDocumenter):
     def get_object_members(self, want_all):
         """Add traits with .tag(config=True) to members list"""
         check, members = super().get_object_members(want_all)
+        if not isinstance(self.object, MetaHasTraits):
+            return check, members
         get_traits = (
             self.object.class_own_traits
             if self.options.inherited_members


### PR DESCRIPTION
Seen while working on https://github.com/jupyter/nbclient/pull/230:

```python
reading sources... [100%] reference/nbclient.tests
Exception occurred:
  File "/Users/silvester/miniconda/envs/nbclient_env/lib/python3.10/site-packages/autodoc_traits/autodoc_traits.py", line 20, in get_object_members
    else self.object.class_traits
AttributeError: type object 'NBClientTestsBase' has no attribute 'class_traits'
```