### PR TITLE
single file module

### DIFF
--- a/autodoc_traits.py
+++ b/autodoc_traits.py
@@ -7,6 +7,11 @@ https://www.sphinx-doc.org/en/master/development/tutorials/autodoc_ext.html#writ
 from sphinx.ext.autodoc import AttributeDocumenter, ClassDocumenter
 from traitlets import MetaHasTraits, TraitType, Undefined
 
+# __version__ should be updated using tbump, based on configuration in
+# pyproject.toml, according to instructions in RELEASE.md.
+#
+__version__ = "1.0.0"
+
 
 class ConfigurableDocumenter(ClassDocumenter):
     """Specialized Documenter subclass for traits with config=True"""

--- a/autodoc_traits/__init__.py
+++ b/autodoc_traits/__init__.py
@@ -1,2 +1,0 @@
-from ._version import __version__  # noqa
-from .autodoc_traits import ConfigurableDocumenter, TraitDocumenter, setup  # noqa

--- a/autodoc_traits/_version.py
+++ b/autodoc_traits/_version.py
@@ -1,4 +1,0 @@
-# __version__ should be updated using tbump, based on configuration in
-# pyproject.toml, according to instructions in RELEASE.md.
-#
-__version__ = "1.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ build-backend = "hatchling.build"
 # hatch ref: https://hatch.pypa.io/latest/
 #
 [tool.hatch.version]
-path = "autodoc_traits/_version.py"
+path = "autodoc_traits.py"
 
 # autoflake is used for autoformatting Python code
 #
@@ -111,4 +111,4 @@ tag_template = "{new_version}"
 # section containing the path of the file, relative to the
 # tbump.toml location.
 [[tool.tbump.file]]
-src = "autodoc_traits/_version.py"
+src = "autodoc_traits.py"


### PR DESCRIPTION
This package only contains one thing, so it might as well be in one file. no need to split a tiny package across 3 modules.

If it grows for some reason, splitting it into a directory is always fine and has no compatibility consequences.

It's small, but there are efficiency consequences to overly splitting files, and it adds up when done across packages.