### PR TITLE
avoid putting `c.Class.trait` annotation on non-config traits

### DIFF
--- a/autodoc_traits.py
+++ b/autodoc_traits.py
@@ -165,11 +165,15 @@ class TraitDocumenter(AttributeDocumenter):
         else:
             default_value = repr(default_value)
 
-        self.options.annotation = "c.{name} = {traitlets_type}({default_value})".format(
-            name=self.format_name(),  # TestConfigurator.trait
-            traitlets_type=self.object.__class__.__name__,  # Bool
-            default_value=default_value,
-        )
+        traitlets_type = traitlets_type = self.object.__class__.__name__  # Bool
+
+        if self.object.metadata.get("config"):
+            # add config prefix (c.TestConfigurator.trait = ) if it's configurable
+            config_prefix = f"c.{self.format_name()} = "
+        else:
+            config_prefix = ""
+
+        self.options.annotation = f"{config_prefix}{traitlets_type}({default_value})"
 
         super().add_directive_header(sig)
 

--- a/autodoc_traits.py
+++ b/autodoc_traits.py
@@ -165,7 +165,7 @@ class TraitDocumenter(AttributeDocumenter):
         else:
             default_value = repr(default_value)
 
-        traitlets_type = traitlets_type = self.object.__class__.__name__  # Bool
+        traitlets_type = self.object.__class__.__name__  # Bool
 
         if self.object.metadata.get("config"):
             # add config prefix (c.TestConfigurator.trait = ) if it's configurable

--- a/tests/test_autodoc_traits.py
+++ b/tests/test_autodoc_traits.py
@@ -105,9 +105,11 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
         (
             "autotrait/noconfig.rst",
             [
+                "Bool(False)",
+            ],
+            [
                 "c.SampleConfigurable.trait_noconfig",
             ],
-            [],
         ),
         (
             "autotrait/nohelp.rst",


### PR DESCRIPTION
Before (misleading indication that it's configurable):

![Screenshot 2022-12-15 at 14 26 22](https://user-images.githubusercontent.com/151929/207870696-0c9f183e-c1bd-46f3-8a3e-cce3800214f9.png)


After:

![Screenshot 2022-12-15 at 14 25 52](https://user-images.githubusercontent.com/151929/207870792-844c77c1-13bb-42c0-afa9-af0d69d778c2.png)
