### PR TITLE
register traits with a help string as documented for `autoclass`

### DIFF
--- a/tests/docs/source/autotrait/nohelp.rst
+++ b/tests/docs/source/autotrait/nohelp.rst
@@ -4,5 +4,12 @@ autotrait - no help
 Test that we fall back to present the trait's header even if it lacks a ``help``
 string.
 
+.. note::
+
+   This may include the missing help string message
+   if built together with autoconfigurable,
+   which patches config=True traits to have a truthy help string.
+   This is unrealistic in real docs, but also fairly harmless.
+
 .. autotrait:: sample_module.SampleConfigurable.trait_nohelp
    :noindex:

--- a/tests/test_autodoc_traits.py
+++ b/tests/test_autodoc_traits.py
@@ -24,10 +24,11 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
             "autoclass/members.rst",
             [
                 "c.SampleConfigurable.trait",
-                "c.SampleConfigurable.trait_nohelp",
                 "trait_noconfig",
             ],
-            [],
+            [
+                "c.SampleConfigurable.trait_nohelp",
+            ],
         ),
         (
             "autoclass/undoc_members.rst",
@@ -123,9 +124,10 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
             "autotrait/nohelp.rst",
             [
                 "c.SampleConfigurable.trait_nohelp",
+            ],
+            [
                 "No help string is provided.",
             ],
-            [],
         ),
         ("autotrait/non_trait_raises_error.rst", [], []),
     ],

--- a/tests/test_autodoc_traits.py
+++ b/tests/test_autodoc_traits.py
@@ -22,15 +22,18 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
     [
         (
             "autoclass/members.rst",
-            [],
             [
                 "c.SampleConfigurable.trait",
+                "c.SampleConfigurable.trait_nohelp",
+                "trait_noconfig",
             ],
+            [],
         ),
         (
             "autoclass/undoc_members.rst",
             [
                 "c.SampleConfigurable.trait",
+                "c.SampleConfigurable.trait_nohelp",
             ],
             [],
         ),
@@ -47,6 +50,7 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
             [
                 "c.SampleConfigurableSubclass.trait",
                 "c.SampleConfigurableSubclass.subclass_trait",
+                "trait_noconfig",
                 "method docstring",
             ],
             [],
@@ -55,11 +59,14 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
             "autoconfigurable/members.rst",
             [
                 "c.SampleConfigurableSubclass.subclass_trait",
+                "c.SampleConfigurableSubclass.trait_nohelp",
+                "trait_noconfig",
+                "No help string is provided.",
                 "c.SampleConfigurableSubclass.trait",
                 "method docstring",
             ],
             [
-                "trait_noconfig help text",
+                "c.SampleConfigurableSubclass.trait_noconfig",
             ],
         ),
         (
@@ -69,7 +76,7 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
                 "c.SampleConfigurableSubclass.trait",
             ],
             [
-                "trait_noconfig help text",
+                "trait_noconfig",
                 "method docstring",
             ],
         ),
@@ -105,6 +112,7 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
         (
             "autotrait/noconfig.rst",
             [
+                "trait_noconfig",
                 "Bool(False)",
             ],
             [
@@ -115,6 +123,7 @@ def test_sphinx_build_all_docs(temp_docs_dir, monkeypatch):
             "autotrait/nohelp.rst",
             [
                 "c.SampleConfigurable.trait_nohelp",
+                "No help string is provided.",
             ],
             [],
         ),


### PR DESCRIPTION
by setting `trait.__doc__ = trait.help` while looking up attributes on MetaHasTraits

## Change

For `autoclass`, traits are now filtered automatically and as-expected, as controlled by `:members:` and friends (closes #30), matching handling of all other attributes.

Draft because I haven't updated the tests, and I'm not 100% sure what to do on autoconfigurable's get_object_members now. I removed the `__doc__` 'hack' to inject _all_ config, which changes the default for `autoconfigurable` to include all _documented_ config options by default, and you have to use `:members:` or `:undoc-members:` to include undocumented config members.

There is no simple option to include _only_ all configurable options, including those without help strings, which is the current default behavior. I think this might be the right thing to do, though, as removing a help string from an option is a standard signal that it shouldn't be included in docs.

So the change in behavior:

- `autoclass` picks up traits (or not) based on their `help` string as if it is the docstring, so they are collected as expected via `:members:`, `:undoc-members:`, etc.
- `autoconfigurable` still unconditionally adds all `config=True` traits to the member list, but actually undocumented config traits will get filtered out (A good change, I think, but I'm open to discussion on this one).

### related:

Related: https://github.com/ipython/traitlets/pull/816 removes the need for the `__doc__` injection by doing it in traitlets by default.