### PR TITLE
sphinx 7.2 compatibility, require sphinx 4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,19 +34,19 @@ jobs:
           #       https://github.com/sphinx-doc/sphinx/issues/10291#issuecomment-1079709635.
           #
           - python-version: "3.8"
-            sphinx-version: "2.*"
+            sphinx-version: "4.*"
             traitlets-version: "4.*"
             pip-install-addition: "'jinja2<3.1'"
           - python-version: "3.9"
-            sphinx-version: "3.*"
+            sphinx-version: "5.*"
             traitlets-version: "4.*"
             pip-install-addition: "'jinja2<3.1'"
           - python-version: "3.10"
-            sphinx-version: "4.*"
+            sphinx-version: "6.*"
             traitlets-version: "5.*"
             pip-install-addition: ""
           - python-version: "3.11"
-            sphinx-version: "5.*"
+            sphinx-version: "7.*"
             traitlets-version: "5.*"
             pip-install-addition: ""
 

--- a/autodoc_traits.py
+++ b/autodoc_traits.py
@@ -7,7 +7,7 @@ https://www.sphinx-doc.org/en/master/development/tutorials/autodoc_ext.html#writ
 
 import warnings
 
-from sphinx.ext.autodoc import AttributeDocumenter, ClassDocumenter
+from sphinx.ext.autodoc import AttributeDocumenter, ClassDocumenter, ObjectMember
 from sphinx.util.inspect import safe_getattr
 from traitlets import MetaHasTraits, TraitType, Undefined
 
@@ -75,6 +75,7 @@ class ConfigurableDocumenter(ClassDocumenter):
         - traitlets.HasTraits.class_traits:   https://github.com/ipython/traitlets/blob/v5.6.0/traitlets/traitlets.py#L1620-L1652
         """
         check, members = super().get_object_members(want_all)
+        existing_member_names = {m.__name__ for m in members}
 
         # We add all _configurable_ traits, including inherited, even if they
         # weren't included via :members: or :inherited-members: options.
@@ -113,8 +114,10 @@ class ConfigurableDocumenter(ClassDocumenter):
                 # this patch will cause it to have a truthy help string
                 # elsewhere, not just in this autoconfigurable instance.
                 trait.__doc__ = trait.help = "No help string is provided."
-            if trait_tuple not in members:
-                members.append(trait_tuple)
+            if name not in existing_member_names:
+                existing_member_names.add(name)
+
+                members.append(ObjectMember(name, trait))
 
         return check, members
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = {file = "LICENSE"}
 dynamic = ["version"]
 requires-python = ">=3.7"
 dependencies = [
-    "sphinx>=2",
+    "sphinx>=4",
     "traitlets>=4",
 ]
 


### PR DESCRIPTION
The use of tuples for members has been deprecated, and `in` no longer works when comparing tuples and ObjectMembers, resulting in duplicate entries

ObjectMember appears to be pretty old, so I think we can rely on it (**edit:** requires Sphinx 3.4, so bump requirement to Sphinx 4)