### PR TITLE
Remove no longer needed upper bound pin on traitlets

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,6 +45,10 @@ jobs:
             sphinx-version: "7.*"
             traitlets-version: "5.*"
             pip-install-addition: ""
+          - python-version: "3.12"
+            sphinx-version: "7.*"
+            traitlets-version: "5.*"
+            pip-install-addition: ""
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,18 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # NOTE: jinja2<3.1 is added as a workaround to ensure we can test
-          #       against sphinx 2 and 3 that otherwise breaks, see
-          #       https://github.com/sphinx-doc/sphinx/issues/10291#issuecomment-1079709635.
-          #
           - python-version: "3.8"
             sphinx-version: "4.*"
             traitlets-version: "4.*"
-            pip-install-addition: "'jinja2<3.1'"
+            pip-install-addition: ""
           - python-version: "3.9"
             sphinx-version: "5.*"
             traitlets-version: "4.*"
-            pip-install-addition: "'jinja2<3.1'"
+            pip-install-addition: ""
           - python-version: "3.10"
             sphinx-version: "6.*"
             traitlets-version: "5.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,7 @@ dynamic = ["version"]
 requires-python = ">=3.7"
 dependencies = [
     "sphinx>=4",
-    # FIXME: traitlets are upper bounded as a workaround to
-    #        https://github.com/jupyterhub/autodoc-traits/issues/55
-    "traitlets>=4,<5.10",
+    "traitlets>=4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Removes workaround implemented to mitigate https://github.com/jupyterhub/autodoc-traits/issues/55, so this fixes #55.