### PR TITLE
enable trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,12 +26,14 @@ on:
 
 jobs:
   build-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          python-version: "3.11"
+          persist-credentials: false
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6
+        with:
+          python-version: "3.13"
 
       - name: install build package
         run: |
@@ -44,9 +46,29 @@ jobs:
           python -m build --sdist --wheel .
           ls -l dist
 
-      - name: publish to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: startsWith(github.ref, 'refs/tags/')
+      # ref: https://github.com/actions/upload-artifact#readme
+      - name: upload dists
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+          name: ${{ github.repository.name }}-dist
+          path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-24.04
+    if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: release
+    needs:
+      - build-release
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Get release artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: ${{ github.repository.name }}-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1


### PR DESCRIPTION
steps outside this PR:

- [x] enable trusted publishing on PyPI
- [x] create release environment
- [ ] revoke token used to publish last release (does this happen automatically? I can't find the token on PyPI)
